### PR TITLE
Bump nuget dependencies to use ChakraCore 1.7.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ BaristaCore
 | __macOS 10.12.1 (x64)__       | [![Build Status](https://travis-ci.org/BaristaLabs/BaristaCore.svg?branch=master)](https://travis-ci.org/BaristaLabs/BaristaCore) |
 
 
-> **12/19/2017** *BaristaCore is currently in active development. The functionality described below indicates the design goals of BaristaCore and may not be all currently implemented.*
+> **01/12/2017** *BaristaCore is currently in active development. The functionality described below indicates the design goals of BaristaCore and may not be all currently implemented.*
 
-> Updated with ChakraCore 1.7.5
+> Updated with ChakraCore 1.7.6
 
 Provides a sandboxed JavaScript runtime natively to a .Net Standard 2.0 application on Windows, Linux and macOS.
 

--- a/src/BaristaLabs.BaristaCore.Portafilter/BaristaLabs.BaristaCore.Portafilter.csproj
+++ b/src/BaristaLabs.BaristaCore.Portafilter/BaristaLabs.BaristaCore.Portafilter.csproj
@@ -11,7 +11,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="BaristaLabs.BaristaCore.ChakraCore.win-x64" Version="1.7.6-beta2" />
+    <PackageReference Include="BaristaLabs.BaristaCore.ChakraCore.win-x64" Version="1.7.6" />
     <PackageReference Include="BaristaLabs.BaristaCore.Common" Version="1.0.1-beta05" />
     <PackageReference Include="BaristaLabs.BaristaCore.Extensions" Version="1.0.1-beta05" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.7" />

--- a/src/BaristaServer/BaristaServer.csproj
+++ b/src/BaristaServer/BaristaServer.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BaristaLabs.BaristaCore.ChakraCore" Version="1.7.6-beta2" />
+    <PackageReference Include="BaristaLabs.BaristaCore.ChakraCore" Version="1.7.6" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.5" />
   </ItemGroup>
 

--- a/test/BaristaLabs.BaristaCore.Extensions.Tests/BaristaLabs.BaristaCore.Extensions.Tests.csproj
+++ b/test/BaristaLabs.BaristaCore.Extensions.Tests/BaristaLabs.BaristaCore.Extensions.Tests.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BaristaLabs.BaristaCore.ChakraCore" Version="1.7.6-beta2" />
+    <PackageReference Include="BaristaLabs.BaristaCore.ChakraCore" Version="1.7.6" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/test/BaristaLabs.BaristaCore.Tests/BaristaLabs.BaristaCore.Tests.csproj
+++ b/test/BaristaLabs.BaristaCore.Tests/BaristaLabs.BaristaCore.Tests.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BaristaLabs.BaristaCore.ChakraCore" Version="1.7.6-beta2" />
+    <PackageReference Include="BaristaLabs.BaristaCore.ChakraCore" Version="1.7.6" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />

--- a/test/BaristaLabs.BaristaCore.Tests/JavaScript/ICoreJavaScriptEngine_Facts.cs
+++ b/test/BaristaLabs.BaristaCore.Tests/JavaScript/ICoreJavaScriptEngine_Facts.cs
@@ -685,104 +685,105 @@ export default function cube(x) {
         }
 
         //TODO: Keeping the SharedContents an IntPtr for now, as a safehandle seems to corrupt the runtime until a hard reboot.
+        //TODO: These unit tests are disabled in 1.7.6 due to potential timing attacks irt spectre.
 
-        [Fact]
-        public void JsSharedArrayBufferWithSharedContentCanBeRetrieved()
-        {
-            var source = @"(() => {
-        return new SharedArrayBuffer(50);
-        })();
-        ";
-            using (var runtimeHandle = Engine.JsCreateRuntime(JavaScriptRuntimeAttributes.None, null))
-            {
-                using (var contextHandle = Engine.JsCreateContext(runtimeHandle))
-                {
-                    Engine.JsSetCurrentContext(contextHandle);
+        //[Fact]
+        //public void JsSharedArrayBufferWithSharedContentCanBeRetrieved()
+        //{
+        //    var source = @"(() => {
+        //return new SharedArrayBuffer(50);
+        //})();
+        //";
+        //    using (var runtimeHandle = Engine.JsCreateRuntime(JavaScriptRuntimeAttributes.None, null))
+        //    {
+        //        using (var contextHandle = Engine.JsCreateContext(runtimeHandle))
+        //        {
+        //            Engine.JsSetCurrentContext(contextHandle);
 
-                    var sharedArrayBufferHandle = Engine.JsRunScript(source);
-                    var handleType = Engine.JsGetValueType(sharedArrayBufferHandle);
+        //            var sharedArrayBufferHandle = Engine.JsRunScript(source);
+        //            var handleType = Engine.JsGetValueType(sharedArrayBufferHandle);
 
-                    //Apparently the type is object for now.
-                    Assert.True(handleType == JsValueType.Object);
+        //            //Apparently the type is object for now.
+        //            Assert.True(handleType == JsValueType.Object);
 
-                    Internal.LibChakraCore.JsGetSharedArrayBufferContent(sharedArrayBufferHandle, out IntPtr sharedContents);
-                    Assert.True(sharedContents != IntPtr.Zero);
+        //            Internal.LibChakraCore.JsGetSharedArrayBufferContent(sharedArrayBufferHandle, out IntPtr sharedContents);
+        //            Assert.True(sharedContents != IntPtr.Zero);
 
-                    Internal.LibChakraCore.JsReleaseSharedArrayBufferContentHandle(sharedContents);
+        //            Internal.LibChakraCore.JsReleaseSharedArrayBufferContentHandle(sharedContents);
 
-                    sharedArrayBufferHandle.Dispose();
-                }
-            }
-        }
+        //            sharedArrayBufferHandle.Dispose();
+        //        }
+        //    }
+        //}
 
-        [Fact]
-        public void JsSharedArrayBufferWithSharedContentCanBeCreated()
-        {
-            var source = @"(() => {
-        return new SharedArrayBuffer(50);
-        })();
-        ";
+        //[Fact]
+        //public void JsSharedArrayBufferWithSharedContentCanBeCreated()
+        //{
+        //    var source = @"(() => {
+        //return new SharedArrayBuffer(50);
+        //})();
+        //";
 
-            using (var runtimeHandle = Engine.JsCreateRuntime(JavaScriptRuntimeAttributes.None, null))
-            {
-                using (var contextHandle = Engine.JsCreateContext(runtimeHandle))
-                {
-                    Engine.JsSetCurrentContext(contextHandle);
+        //    using (var runtimeHandle = Engine.JsCreateRuntime(JavaScriptRuntimeAttributes.None, null))
+        //    {
+        //        using (var contextHandle = Engine.JsCreateContext(runtimeHandle))
+        //        {
+        //            Engine.JsSetCurrentContext(contextHandle);
 
-                    var sharedArrayBufferHandle = Engine.JsRunScript(source);
-                    var handleType = Engine.JsGetValueType(sharedArrayBufferHandle);
+        //            var sharedArrayBufferHandle = Engine.JsRunScript(source);
+        //            var handleType = Engine.JsGetValueType(sharedArrayBufferHandle);
 
-                    //Apparently the type is object for now.
-                    Assert.True(handleType == JsValueType.Object);
+        //            //Apparently the type is object for now.
+        //            Assert.True(handleType == JsValueType.Object);
 
-                    var sharedBufferContentHandle = Engine.JsGetSharedArrayBufferContent(sharedArrayBufferHandle);
-                    Assert.True(sharedBufferContentHandle != IntPtr.Zero);
+        //            var sharedBufferContentHandle = Engine.JsGetSharedArrayBufferContent(sharedArrayBufferHandle);
+        //            Assert.True(sharedBufferContentHandle != IntPtr.Zero);
 
-                    var sharedArrayHandle = Engine.JsCreateSharedArrayBufferWithSharedContent(sharedBufferContentHandle);
-                    Assert.True(sharedArrayHandle != JavaScriptValueSafeHandle.Invalid);
+        //            var sharedArrayHandle = Engine.JsCreateSharedArrayBufferWithSharedContent(sharedBufferContentHandle);
+        //            Assert.True(sharedArrayHandle != JavaScriptValueSafeHandle.Invalid);
 
-                    handleType = Engine.JsGetValueType(sharedArrayHandle);
-                    Assert.True(handleType == JsValueType.Object);
+        //            handleType = Engine.JsGetValueType(sharedArrayHandle);
+        //            Assert.True(handleType == JsValueType.Object);
 
-                    Internal.LibChakraCore.JsReleaseSharedArrayBufferContentHandle(sharedBufferContentHandle);
+        //            Internal.LibChakraCore.JsReleaseSharedArrayBufferContentHandle(sharedBufferContentHandle);
 
-                    sharedArrayBufferHandle.Dispose();
-                    sharedArrayHandle.Dispose();
-                }
-            }
-        }
+        //            sharedArrayBufferHandle.Dispose();
+        //            sharedArrayHandle.Dispose();
+        //        }
+        //    }
+        //}
 
-        [Fact]
-        public void JsSharedArrayBufferWithSharedContentCanBeReleased()
-        {
-            var source = @"(() => {
-        return new SharedArrayBuffer(50);
-        })();
-        ";
+        //[Fact]
+        //public void JsSharedArrayBufferWithSharedContentCanBeReleased()
+        //{
+        //    var source = @"(() => {
+        //return new SharedArrayBuffer(50);
+        //})();
+        //";
 
-            using (var runtimeHandle = Engine.JsCreateRuntime(JavaScriptRuntimeAttributes.None, null))
-            {
-                using (var contextHandle = Engine.JsCreateContext(runtimeHandle))
-                {
-                    Engine.JsSetCurrentContext(contextHandle);
+        //    using (var runtimeHandle = Engine.JsCreateRuntime(JavaScriptRuntimeAttributes.None, null))
+        //    {
+        //        using (var contextHandle = Engine.JsCreateContext(runtimeHandle))
+        //        {
+        //            Engine.JsSetCurrentContext(contextHandle);
 
-                    var sharedArrayBufferHandle = Engine.JsRunScript(source);
-                    var handleType = Engine.JsGetValueType(sharedArrayBufferHandle);
+        //            var sharedArrayBufferHandle = Engine.JsRunScript(source);
+        //            var handleType = Engine.JsGetValueType(sharedArrayBufferHandle);
 
-                    //Apparently the type is object for now.
-                    Assert.True(handleType == JsValueType.Object);
+        //            //Apparently the type is object for now.
+        //            Assert.True(handleType == JsValueType.Object);
 
-                    var sharedBufferContentHandle = Engine.JsGetSharedArrayBufferContent(sharedArrayBufferHandle);
-                    Assert.True(sharedBufferContentHandle != IntPtr.Zero);
+        //            var sharedBufferContentHandle = Engine.JsGetSharedArrayBufferContent(sharedArrayBufferHandle);
+        //            Assert.True(sharedBufferContentHandle != IntPtr.Zero);
 
-                    Engine.JsReleaseSharedArrayBufferContentHandle(sharedBufferContentHandle);
+        //            Engine.JsReleaseSharedArrayBufferContentHandle(sharedBufferContentHandle);
 
-                    //TODO: we called it, but unsure how to verify that it has been released -- calling Get again still returns the obj.
+        //            //TODO: we called it, but unsure how to verify that it has been released -- calling Get again still returns the obj.
 
-                    sharedArrayBufferHandle.Dispose();
-                }
-            }
-        }
+        //            sharedArrayBufferHandle.Dispose();
+        //        }
+        //    }
+        //}
 
         [Fact]
         public void JsDataViewInfoCanBeRetrieved()


### PR DESCRIPTION
Comment out unit tests against SharedArrayBuffer as they are disabled due to Spectre.